### PR TITLE
add option to use 'checked' prop to pass a default checked value

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ export default class App extends Component {
     }
   ```
 
+###checked - optional
+  Set checked prop equal to the value of the item that you wish to be checked by default. 
+
+  example: 
+  ```javascript
+  <RadioButtonGroup listOfItems={this.state.radioOptions} selectedItemCallback={(value) => this.handleSelection(value)} checked='CreditCard'/>
+  ````
+ 
 ##Customing button colors (The default colors are shown below):
 
 Add these to your custom css file and should be ideally changing the color for which ever color scheme you use.

--- a/src/components/RadioButtonGroup/index.js
+++ b/src/components/RadioButtonGroup/index.js
@@ -7,7 +7,7 @@ export default class RadioButtonGroup extends Component {
   constructor(props) {
     super(props);
     this.listOfItems = props.listOfItems;
-    this.state = {optionsVal: ''};
+    this.state = {optionsVal: props.checked};
   }
 
   handleQueryOpChange(e) {


### PR DESCRIPTION
This change allows a user to add the value of the item which they want to be checked by default. 
Fixes #2 

For example,

``` javascript
<RadioButtonGroup 
    listOfItems=[{ value: 'CreditCard', text: 'Credit Card'}, 
                        { value: 'DebitCard', text: 'Debit Card'}]
   selectedItemCallback={(value) => this.handleSelection(value)} 
   checked='CreditCard'  />
```

Any and all edits welcome. I am new to contributing to open source and found this repo via CodeTriage so if there are things I could be doing better please let me know :)