### PR TITLE
Separate prop-types

### DIFF
--- a/src/components/RadioButtonGroup/index.js
+++ b/src/components/RadioButtonGroup/index.js
@@ -1,6 +1,7 @@
 import './index.css';
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types'
 
 export default class RadioButtonGroup extends Component {
 


### PR DESCRIPTION
Uncaught TypeError: Cannot read property 'array' of undefined

Prop-Types are now a separately maintained library named prop-types.
https://reactjs.org/docs/typechecking-with-proptypes.html